### PR TITLE
replace cp_static.sh with build script

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "rustw"
 version = "0.1.0"
 authors = ["Nick Cameron <ncameron@mozilla.com>"]
+build = "build.rs"
 
 [dependencies]
 url = "0.5"
@@ -15,3 +16,6 @@ toml = "0.1"
 [dependencies.hyper]
 version = "0.8"
 default-features = false
+
+[build-dependencies]
+walkdir = "0.1"

--- a/README.md
+++ b/README.md
@@ -33,19 +33,14 @@ Motivation:
 
 ## Building
 
-You must perform the first and last step, the second is optional. They must be
+You must perform the first step, the second is optional. They must be
 performed in order. Requires a nightly version of Rust to build.
 
-* `cargo build` to build the Rust parts.
+* `cargo build --release` to build the Rust parts.
 
 * `./build_templates.sh` to rebuild the handlebars templates. The compiled targets
   are part of the repo, so you shouldn't need to do this unless you edit the
   templates. You will need handlebars installed to do this.
-
-* `./cp_static.sh` to copy the staticly served files to the target
-  directory. This will only work for debug builds. We should use a Cargo build
-  script really.
-
 
 ## Running
 

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,45 @@
+// Copyright 2016 The Rustw Project Developers.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+extern crate walkdir;
+use walkdir::WalkDir;
+use std::{env, fs};
+use std::path::Path;
+
+fn main() {
+    // copy from $CARGO_MANIFEST_DIR to $CARGO_MANIFEST_DIR/target/$PROFILE
+    let from = env::var("CARGO_MANIFEST_DIR").unwrap();
+    let from = Path::new(&from);
+    let to = {
+        let mut buf = from.to_owned();
+        buf.push("target");
+        buf.push(env::var("PROFILE").unwrap());
+        buf
+    };
+
+    // don't rerun on every build, but do rebuild if the build script changes
+    // or something changes in the directory
+    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=static");
+
+    // copy the "static" dir and all its contents
+    for entry in WalkDir::new(from.join("static"))
+                         .into_iter()
+                         .filter_map(|e| e.ok()) {
+        let mut target = to.clone();
+        let relative = entry.path().strip_prefix(from).unwrap();
+        println!("cargo:rerun-if-changed={}", relative.display());
+        target.push(relative);
+        if entry.file_type().is_dir() {
+            fs::create_dir_all(target).unwrap();
+        } else {
+            fs::copy(entry.path(), target).unwrap();
+        }
+    }
+}
+

--- a/cp_static.sh
+++ b/cp_static.sh
@@ -1,4 +1,0 @@
-# Copy data to install directory.
-# TODO better to do this in a Cargo build script.
-
-cp -r static target/debug


### PR DESCRIPTION
Removes `cp_static.sh` and adds a build script to do the same, using the `walkdir` crate. Works with either debug or release build.