### PR TITLE
Hide return to build results button on build page

### DIFF
--- a/static/reducers.js
+++ b/static/reducers.js
@@ -107,6 +107,7 @@ function build(state = BuildState.FRESH, action) {
         case DO_BUILD:
             return BuildState.BUILDING;
         case BUILD_COMPLETE:
+        case SHOW_BUILD_RESULTS:
             return BuildState.BUILT;
         case SHOW_ERR_CODE:
         case SHOW_SEARCH:


### PR DESCRIPTION
Reshuffling the build states slightly to set visibleHomeLink to false on the build results page.

Fixes issue #152