### PR TITLE
Limit ESLint to relevant JS files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
 
 script:
   - cargo build
-  - ./node_modules/travis-github-lint-status/index.js
+  - cd static && ./node_modules/travis-github-lint-status/index.js

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
     "build": "webpack"
   },
   "dependencies": {
+    "eslint-plugin-jquery": "^1.2.1",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.5",

--- a/static/.eslintignore
+++ b/static/.eslintignore
@@ -1,0 +1,4 @@
+libs
+*.out.js
+*.map
+*.json

--- a/static/.eslintrc
+++ b/static/.eslintrc
@@ -1,9 +1,13 @@
 {
   "globals": {},
-  "env": {},
+  "env": {
+    "browser": true,
+    "jquery": true
+  },
   "rules": {},
   "plugins": [
-    "react"
+    "react",
+    "jquery"
   ],
   "extends": [
     "eslint:recommended",


### PR DESCRIPTION
At the moment, ESLint has not been properly configured for this repository. As a result, it is being run on many irrelevant files including the results of building the crate, artificially inflating the number of errors.

 This PR:
- Makes sure ESLint is run only on the relevant files in the static/ directory.
- Adds the eslint-jquery-plugin and browser and jquery environments.
- Updates Travis CI to run ESLint with the desired behaviour.