### PR TITLE
Fix path in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,4 +9,4 @@ install:
 
 script:
   - cargo build
-  - cd static && ./node_modules/travis-github-lint-status/index.js
+  - cd static && ./../node_modules/travis-github-lint-status/index.js


### PR DESCRIPTION
Use the correct path for /travis-github-lint-status after changing directory in .travis.yml.

(Previous PR to update .travis.yml was approved before I could check the CI 😬 )